### PR TITLE
Fixed wrong usage of path.extname

### DIFF
--- a/katalonTask/src/agent/katalon-studio.js
+++ b/katalonTask/src/agent/katalon-studio.js
@@ -51,7 +51,7 @@ function getKsLocation(ksVersionNumber, ksLocation) {
 
       const fileName = ksVersion.filename;
       const fileExtension = path.extname(fileName);
-      if (!['.zip', '.tar.gz'].includes(fileExtension)) {
+      if (!['.zip', '.gz'].includes(fileExtension)) {
         // eslint-disable-next-line prefer-promise-reject-errors
         return Promise.reject(`Unexpected file name ${fileName}`);
       }


### PR DESCRIPTION
From the official documentation:

The path.extname() method returns the extension of the path, from the last occurrence of the . (period) character to end of string in the last portion of the path

Consider the following json:

{
    "os": "Linux",
    "version": "7.2.1",
    "filename": "Katalon_Studio_Linux_64-7.2.1.tar.gz",
    "url": "https://github.com/katalon-studio/katalon-studio/releases/download/v7.2.1/Katalon_Studio_Engine_Linux_64-7.2.1.tar.gz"
},

path.extname only returns ".gz" in this case, and not ".tar.gz". This is why attempts to install Katalon on a linux system will always return the following error: Unexpected file name Katalon_Studio_Linux_64-7.2.1.tar.gz.

Changed extension from ".tar.gz" to ".gz"