### PR TITLE
Support 'latest' and '10-latest' tag for KRE version

### DIFF
--- a/katalonTask/package.json
+++ b/katalonTask/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katalon-devops-extension",
-  "version": "1.1.3",
+  "version": "1.3.0",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/katalonTask/src/agent/katalon-studio.js
+++ b/katalonTask/src/agent/katalon-studio.js
@@ -46,7 +46,29 @@ function getKsLocation(ksVersionNumber, ksLocation) {
   return http.request(releasesList, '', {}, 'GET')
     .then(({ body }) => {
       const osVersion = os.getVersion();
-      const ksVersion = body.find(item => item.version === ksVersionNumber
+
+      let resolvedVersionNumber = ksVersionNumber;
+      if (ksVersionNumber === 'latest') {
+        defaultLogger.info(`Finding latest version of OS: ${osVersion}`)
+        const osReleases = body.filter(item => item.os === osVersion);
+        if (osReleases.length === 0) {
+          // eslint-disable-next-line prefer-promise-reject-errors
+          return Promise.reject(`No releases found for OS: ${osVersion}`);
+        }
+        osReleases.sort((a, b) => {
+          const pa = a.version.split('.').map(Number);
+          const pb = b.version.split('.').map(Number);
+          for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
+            const diff = (pb[i] || 0) - (pa[i] || 0);
+            if (diff !== 0) return diff;
+          }
+          return 0;
+        });
+        resolvedVersionNumber = osReleases[0].version;
+        defaultLogger.info(`Resolved 'latest' to Katalon Studio version ${resolvedVersionNumber}.`);
+      }
+
+      const ksVersion = body.find(item => item.version === resolvedVersionNumber
         && item.os === osVersion);
 
       const fileName = ksVersion.filename;
@@ -57,14 +79,14 @@ function getKsLocation(ksVersionNumber, ksLocation) {
       }
 
       const userhome = os.getUserHome();
-      const ksLocationParentDir = path.join(userhome, '.katalon', `KRE-${ksVersionNumber}`);
+      const ksLocationParentDir = path.join(userhome, '.katalon', `KRE-${resolvedVersionNumber}`);
       const katalonDoneFilePath = path.join(ksLocationParentDir, '.katalon.done');
 
       if (fs.existsSync(katalonDoneFilePath)) {
         return Promise.resolve({ ksLocationParentDir });
       }
 
-      defaultLogger.info(`Download Katalon Studio ${ksVersionNumber} to ${ksLocationParentDir}.`);
+      defaultLogger.info(`Download Katalon Studio ${resolvedVersionNumber} to ${ksLocationParentDir}.`);
       return file.downloadAndExtract(ksVersion.url, ksLocationParentDir, false)
         .then(() => {
           fs.writeFileSync(katalonDoneFilePath, '');

--- a/katalonTask/src/agent/katalon-studio.js
+++ b/katalonTask/src/agent/katalon-studio.js
@@ -31,6 +31,61 @@ function find(startPath, filter, callback) {
   }
 }
 
+function sortByVersionDesc(releases) {
+  if (!releases || releases.length === 0) return [];
+  return releases.slice().sort((a, b) => {
+    const pa = a.version.split('.').map(Number);
+    const pb = b.version.split('.').map(Number);
+    for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
+      const diff = (pb[i] || 0) - (pa[i] || 0);
+      if (diff !== 0) return diff;
+    }
+    return 0;
+  });
+}
+
+function resolveVersionNumber(ksVersionNumber, osVersion, releases) {
+  const osReleases = releases.filter(item => item.os === osVersion);
+
+  // "latest" — newest release overall
+  if (ksVersionNumber === 'latest') {
+    defaultLogger.info(`Finding latest version for OS: ${osVersion}`);
+    const sorted = sortByVersionDesc(osReleases);
+    const resolved = sorted.length > 0 ? sorted[0].version : null;
+    if (resolved) defaultLogger.info(`Resolved 'latest' to Katalon Studio version ${resolved}.`);
+    return resolved;
+  }
+
+  // "<major>-latest" — newest release within a given major version, e.g. "11-latest"
+  const majorLatestMatch = ksVersionNumber.match(/^(\d+)-latest$/);
+  if (majorLatestMatch) {
+    const major = parseInt(majorLatestMatch[1], 10);
+    defaultLogger.info(`Finding latest version for major ${major} and OS: ${osVersion}`);
+    const majorReleases = osReleases.filter(item => parseInt(item.version.split('.')[0], 10) === major);
+    const sorted = sortByVersionDesc(majorReleases);
+    const resolved = sorted.length > 0 ? sorted[0].version : null;
+    if (resolved) defaultLogger.info(`Resolved '${ksVersionNumber}' to Katalon Studio version ${resolved}.`);
+    return resolved;
+  }
+
+  // exact version — return as-is
+  return ksVersionNumber;
+}
+
+function resolveVersion(ksVersionNumber) {
+  return http.request(releasesList, '', {}, 'GET')
+    .then(({ body }) => {
+      const osVersion = os.getVersion();
+      const resolved = resolveVersionNumber(ksVersionNumber, osVersion, body);
+      if (!resolved) {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        return Promise.reject(`No matching release found for version '${ksVersionNumber}' and OS: ${osVersion}`);
+      }
+      const release = body.find(item => item.version === resolved && item.os === osVersion);
+      return { version: resolved, url: release.url, filename: release.filename };
+    });
+}
+
 function getKsLocation(ksVersionNumber, ksLocation) {
   if (!ksVersionNumber && !ksLocation) {
     // eslint-disable-next-line prefer-promise-reject-errors
@@ -43,39 +98,12 @@ function getKsLocation(ksVersionNumber, ksLocation) {
     });
   }
 
-  return http.request(releasesList, '', {}, 'GET')
-    .then(({ body }) => {
-      const osVersion = os.getVersion();
-
-      let resolvedVersionNumber = ksVersionNumber;
-      if (ksVersionNumber === 'latest') {
-        defaultLogger.info(`Finding latest version of OS: ${osVersion}`)
-        const osReleases = body.filter(item => item.os === osVersion);
-        if (osReleases.length === 0) {
-          // eslint-disable-next-line prefer-promise-reject-errors
-          return Promise.reject(`No releases found for OS: ${osVersion}`);
-        }
-        osReleases.sort((a, b) => {
-          const pa = a.version.split('.').map(Number);
-          const pb = b.version.split('.').map(Number);
-          for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
-            const diff = (pb[i] || 0) - (pa[i] || 0);
-            if (diff !== 0) return diff;
-          }
-          return 0;
-        });
-        resolvedVersionNumber = osReleases[0].version;
-        defaultLogger.info(`Resolved 'latest' to Katalon Studio version ${resolvedVersionNumber}.`);
-      }
-
-      const ksVersion = body.find(item => item.version === resolvedVersionNumber
-        && item.os === osVersion);
-
-      const fileName = ksVersion.filename;
-      const fileExtension = path.extname(fileName);
+  return resolveVersion(ksVersionNumber)
+    .then(({ version: resolvedVersionNumber, url, filename }) => {
+      const fileExtension = path.extname(filename);
       if (!['.zip', '.gz'].includes(fileExtension)) {
         // eslint-disable-next-line prefer-promise-reject-errors
-        return Promise.reject(`Unexpected file name ${fileName}`);
+        return Promise.reject(`Unexpected file name ${filename}`);
       }
 
       const userhome = os.getUserHome();
@@ -87,7 +115,7 @@ function getKsLocation(ksVersionNumber, ksLocation) {
       }
 
       defaultLogger.info(`Download Katalon Studio ${resolvedVersionNumber} to ${ksLocationParentDir}.`);
-      return file.downloadAndExtract(ksVersion.url, ksLocationParentDir, false)
+      return file.downloadAndExtract(url, ksLocationParentDir, false)
         .then(() => {
           fs.writeFileSync(katalonDoneFilePath, '');
           return Promise.resolve({ ksLocationParentDir });
@@ -138,4 +166,6 @@ module.exports = {
   },
 
   getKsLocation,
+
+  resolveVersion,
 };

--- a/katalonTask/src/test_ks_version.js
+++ b/katalonTask/src/test_ks_version.js
@@ -2,16 +2,33 @@
 
 const ks = require('./agent/katalon-studio');
 
-function testGetKsLocation(label, version) {
-  console.log(`\n--- Testing version: ${label} ---`);
-  return ks.getKsLocation(version, '')
-    .then(({ ksLocationParentDir }) => {
-      console.log(`[PASS] Resolved location: ${ksLocationParentDir}`);
+function testResolveVersion(version) {
+  console.log(`\n--- Testing version: ${version} ---`);
+  return ks.resolveVersion(version)
+    .then(({ version: resolved, url }) => {
+      console.log(`Resolved version : ${resolved}`);
+      console.log(`Download URL     : ${url}`);
     })
     .catch((err) => {
       console.error(`[FAIL] Error: ${err}`);
     });
 }
 
-testGetKsLocation('latest', 'latest')
-// testGetKsLocation('10.4.3', '10.4.3')
+
+function testGetKsLocation(version) {
+  console.log(`\n--- Testing version: ${version} ---`);
+  return ks.getKsLocation(version, '')
+    .then(({ ksLocationParentDir }) => {
+      console.log(`[PASS] Resolved location: ${ksLocationParentDir}`);
+
+    })
+    .catch((err) => {
+      console.error(`[FAIL] Error: ${err}`);
+    });
+}
+
+testResolveVersion('latest')
+    .then(() => testResolveVersion('10-latest'))
+    .then(() => testResolveVersion('11-latest'))
+    .then(() => testResolveVersion('10.4.3'))
+    .then(() => testGetKsLocation('11-latest'))

--- a/katalonTask/src/test_ks_version.js
+++ b/katalonTask/src/test_ks_version.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const ks = require('./agent/katalon-studio');
+
+function testGetKsLocation(label, version) {
+  console.log(`\n--- Testing version: ${label} ---`);
+  return ks.getKsLocation(version, '')
+    .then(({ ksLocationParentDir }) => {
+      console.log(`[PASS] Resolved location: ${ksLocationParentDir}`);
+    })
+    .catch((err) => {
+      console.error(`[FAIL] Error: ${err}`);
+    });
+}
+
+testGetKsLocation('latest', 'latest')
+// testGetKsLocation('10.4.3', '10.4.3')

--- a/katalonTask/task.json
+++ b/katalonTask/task.json
@@ -8,7 +8,7 @@
     "author": "Katalon LLC",
     "version": {
         "Major": 1,
-        "Minor": 2,
+        "Minor": 3,
         "Patch": 0
     },
     "minimumAgentVersion": "2.144.0",

--- a/katalonTask/task.json
+++ b/katalonTask/task.json
@@ -19,7 +19,7 @@
             "type": "string",
             "label": "Download Katalon Studio version",
             "defaultValue": "",
-            "helpMarkDown": "E.g. `10.4.2`. \nThe list of all releases can be retrieved from [here](https://github.com/katalon-studio/katalon-studio/releases)."
+            "helpMarkDown": "E.g. `10.4.2` or `latest` to automatically use the most recent stable release. \nThe list of all releases can be retrieved from [here](https://github.com/katalon-studio/katalon-studio/releases)."
         },
         {
             "name": "location",

--- a/katalonTask/task.json
+++ b/katalonTask/task.json
@@ -19,7 +19,7 @@
             "type": "string",
             "label": "Download Katalon Studio version",
             "defaultValue": "",
-            "helpMarkDown": "E.g. `10.4.2` or `latest` to automatically use the most recent stable release. \nThe list of all releases can be retrieved from [here](https://github.com/katalon-studio/katalon-studio/releases)."
+            "helpMarkDown": "E.g. `10.4.2` for an exact version, `latest` for the newest stable release, or `11-latest` for the newest release within a major version. \nThe list of all releases can be retrieved from [here](https://github.com/katalon-studio/katalon-studio/releases)."
         },
         {
             "name": "location",

--- a/package-dev.sh
+++ b/package-dev.sh
@@ -1,0 +1,25 @@
+cd katalonTask 
+npm prune --omit=dev # Equivalent to deprecated 'npm prune --production'
+
+rm -rf build
+
+npx babel src --out-dir build
+cd ..
+tfx extension create --manifest-globs vss-extension-dev.json
+
+# Expected output:
+# == Completed operation: create extension ===
+#  - VSIX: /Users/nga.pham/Documents/workspace/katalon-azure-devops-extension/katalon-llc.katalon-dev-1.3.0.vsix
+#  - Extension ID: katalon-dev
+#  - Extension Version: 1.3.0
+#  - Publisher: katalon-llc
+
+# Remove arm64 in xml file.
+# Need to update `EXTENSION_FILENAME` accordingly 
+export EXTENSION_FILENAME=katalon-llc.katalon-dev-1.3.0.vsix
+unzip -p $EXTENSION_FILENAME '\[Content_Types\].xml' | grep -v 'arm64' > '[Content_Types].xml'
+zip $EXTENSION_FILENAME '[Content_Types].xml'
+
+# Expected output:
+# updating: [Content_Types].xml (deflated 92%)
+

--- a/vss-extension-dev.json
+++ b/vss-extension-dev.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "katalon-dev",
     "name": "Katalon for Azure DevOps - Dev",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "publisher": "katalon-llc",
     "public": false,
     "galleryFlags": [

--- a/vss-extension-dev.json
+++ b/vss-extension-dev.json
@@ -55,13 +55,13 @@
     },
     "contributions": [
         {
-            "id": "katalonTaskDev",
+            "id": "katalonTask",
             "type": "ms.vss-distributed-task.task",
             "targets": [
                 "ms.vss-distributed-task.tasks"
             ],
             "properties": {
-                "name": "katalonTaskDev"
+                "name": "katalonTask"
             }
         }
     ]

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "katalon",
     "name": "Katalon for Azure DevOps",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "publisher": "katalon-llc",
     "public": true,
     "galleryFlags": [


### PR DESCRIPTION
Support 'latest' tag for KRE version

Testing output:
```
--- Testing version: latest ---
GET https://raw.githubusercontent.com/katalon-studio/katalon-studio/master/releases.json 200.
Finding latest version for OS: macOS (app)
Resolved 'latest' to Katalon Studio version 11.1.1.
Resolved version : 11.1.1
Download URL     : https://download.katalon.com/11.1.1/Katalon_Studio_Engine_MacOS-11.1.1.tar.gz

--- Testing version: 10-latest ---
GET https://raw.githubusercontent.com/katalon-studio/katalon-studio/master/releases.json 200.
Finding latest version for major 10 and OS: macOS (app)
Resolved '10-latest' to Katalon Studio version 10.4.3.
Resolved version : 10.4.3
Download URL     : https://download.katalon.com/10.4.3/Katalon_Studio_Engine_MacOS-10.4.3.tar.gz

--- Testing version: 11-latest ---
GET https://raw.githubusercontent.com/katalon-studio/katalon-studio/master/releases.json 200.
Finding latest version for major 11 and OS: macOS (app)
Resolved '11-latest' to Katalon Studio version 11.1.1.                                                                                                      Resolved version : 11.1.1
Download URL     : https://download.katalon.com/11.1.1/Katalon_Studio_Engine_MacOS-11.1.1.tar.gz

--- Testing version: 10.4.3 ---
GET https://raw.githubusercontent.com/katalon-studio/katalon-studio/master/releases.json 200.                                                               Resolved version : 10.4.3
Download URL     : https://download.katalon.com/10.4.3/Katalon_Studio_Engine_MacOS-10.4.3.tar.gz
```

